### PR TITLE
fix: resolve error due to actions/download-artifact: v3 deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
       name: "Integration test for ${{ github.event.client_payload.reference }}"
       url: ${{ github.event.client_payload.url }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: hydephp/action@master
         with:
           debug: true
           upload-artifact: true
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
           path: build


### PR DESCRIPTION
This should resolve the error of the integration tests due to the use of the actions/download-artifact v3 which is deprecated. It also updates the checkout action to v4.

Reference: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

The same PR is made available for the other repo containing integrations tests [here](https://github.com/hyde-staging/github-action-test-project-2/pull/1)